### PR TITLE
MangaDex - MD@Home token handling

### DIFF
--- a/src/all/mangadex/build.gradle
+++ b/src/all/mangadex/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'MangaDex'
     pkgNameSuffix = 'all.mangadex'
     extClass = '.MangaDexFactory'
-    extVersionCode = 94
+    extVersionCode = 95
     libVersion = '1.2'
 }
 


### PR DESCRIPTION
Note: there's still logging that I'll remove before PRing to the main repo and `refreshTokenAfter` will be increased (to 5 minutes I guess or 30 if they agree to up token expiration).  

If there's a good way to check a cache's age, I could use that instead of the HashMap I'm using.