### PR TITLE
Add an option to only use MD@H nodes that use port 443 (the official SSL/TLS port)

### DIFF
--- a/src/all/mangadex/build.gradle
+++ b/src/all/mangadex/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'MangaDex'
     pkgNameSuffix = 'all.mangadex'
     extClass = '.MangaDexFactory'
-    extVersionCode = 107
+    extVersionCode = 108
     libVersion = '1.2'
     containsNsfw = true
 }

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MDConstants.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MDConstants.kt
@@ -25,6 +25,10 @@ object MDConstants {
     const val dataSaverPrefTitle = "Data saver"
     const val dataSaverPrefSummary = "Enables smaller more compressed images"
     const val dataSaverPref = "dataSaverV5"
+    
+    const val standardHTTPSPrefTitle = "Standard HTTPS only"
+    const val standardHTTPSPrefSummary = "Enable only MD@H nodes with standard HTTPS. This enable users in some business and school networks to access MangaDex normally"
+    const val standardHTTPSPref = "standardHTTPSV5"
 
     const val mdAtHomeTokenLifespan = 10 * 60 * 1000
 }


### PR DESCRIPTION
This should close feature request tachiyomiorg/tachiyomi-extensions#6881 except that strings might be modified if necessary.